### PR TITLE
Fix prediction output readability and simplify inference installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ correlations with human ratings.
 
 ## Usage
 
+For inference only, install the dependencies from `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+If you also want to run the meta-evaluation scripts, install the
+`mt-metrics-eval` dependency separately:
+
+```bash
+pip install git+https://github.com/google-research/mt-metrics-eval
+```
+
 The `metricx24/predict.py` and `metricx23/predict.py` scripts contain examples
 for how to run inference on the models.
 

--- a/metricx23/predict.py
+++ b/metricx23/predict.py
@@ -129,7 +129,9 @@ def main() -> None:
 
   if torch.cuda.is_available():
     device = torch.device("cuda")
-    per_device_batch_size = args.batch_size // torch.cuda.device_count()
+    per_device_batch_size = max(
+        1, args.batch_size // max(1, torch.cuda.device_count())
+    )
   else:
     device = torch.device("cpu")
     per_device_batch_size = args.batch_size
@@ -149,13 +151,19 @@ def main() -> None:
   )
 
   training_args = transformers.TrainingArguments(
-      output_dir=os.path.dirname(args.output_file),
+      output_dir=os.path.dirname(args.output_file) or ".",
       per_device_eval_batch_size=per_device_batch_size,
       dataloader_pin_memory=False,
+  )
+  data_collator = transformers.DataCollatorWithPadding(
+      tokenizer=tokenizer,
+      padding="longest",
+      return_tensors="pt",
   )
   trainer = transformers.Trainer(
       model=model,
       args=training_args,
+      data_collator=data_collator,
   )
   predictions, _, _ = trainer.predict(test_dataset=ds["test"])
 
@@ -163,13 +171,13 @@ def main() -> None:
   if dirname:
     os.makedirs(dirname, exist_ok=True)
 
-  with open(args.output_file, "w") as out:
+  with open(args.output_file, "w", encoding="utf-8") as out:
     for pred, example in zip(predictions, ds["test"]):
       example["prediction"] = float(pred)
       del example["input"]
       del example["input_ids"]
       del example["attention_mask"]
-      out.write(json.dumps(example) + "\n")
+      out.write(json.dumps(example, ensure_ascii=False) + "\n")
 
 
 if __name__ == "__main__":

--- a/metricx24/predict.py
+++ b/metricx24/predict.py
@@ -154,7 +154,7 @@ def main() -> None:
   )
 
   training_args = transformers.TrainingArguments(
-      output_dir=os.path.dirname(args.output_file),
+      output_dir=os.path.dirname(args.output_file) or ".",
       per_device_eval_batch_size=per_device_batch_size,
       dataloader_pin_memory=False,
   )
@@ -168,13 +168,13 @@ def main() -> None:
   if dirname:
     os.makedirs(dirname, exist_ok=True)
 
-  with open(args.output_file, "w") as out:
+  with open(args.output_file, "w", encoding="utf-8") as out:
     for pred, example in zip(predictions, ds["test"]):
       example["prediction"] = float(pred)
       del example["input"]
       del example["input_ids"]
       del example["attention_mask"]
-      out.write(json.dumps(example) + "\n")
+      out.write(json.dumps(example, ensure_ascii=False) + "\n")
 
 
 if __name__ == "__main__":

--- a/metricx24/predict.py
+++ b/metricx24/predict.py
@@ -161,6 +161,7 @@ def main() -> None:
   trainer = transformers.Trainer(
       model=model,
       args=training_args,
+      data_collator=transformers.DataCollatorWithPadding(tokenizer),
   )
   predictions, _, _ = trainer.predict(test_dataset=ds["test"])
 

--- a/metricx24/score_dialog_outputs.py
+++ b/metricx24/score_dialog_outputs.py
@@ -251,6 +251,7 @@ def main() -> None:
   trainer = transformers.Trainer(
       model=model,
       args=training_args,
+      data_collator=transformers.DataCollatorWithPadding(tokenizer),
   )
 
   summary = []

--- a/metricx24/score_dialog_outputs.py
+++ b/metricx24/score_dialog_outputs.py
@@ -1,0 +1,336 @@
+# coding=utf-8
+"""Batch-scores chat-style translation outputs with a MetricX-24 model.
+
+Input files are expected to contain one JSON array per line, for example:
+[
+  {"role": "user", "content": "请将以下句子翻译成英语，只输出译文即可，不要输出其他内容：<source>"},
+  {"role": "assistant", "content": "<hypothesis>"}
+]
+
+The script converts each line into MetricX QE input with:
+  source = extracted source text from the user prompt
+  hypothesis = assistant content
+  reference = ""
+"""
+
+import dataclasses
+import json
+import os
+from typing import Any
+
+import datasets
+from metricx24 import models
+import numpy as np
+import torch
+import transformers
+
+
+DEFAULT_PROMPT_PREFIXES = [
+    "请将以下句子翻译成英语，只输出译文即可，不要输出其他内容：",
+]
+
+
+@dataclasses.dataclass
+class Arguments:
+  tokenizer: str = dataclasses.field(
+      metadata={"help": "The tokenizer name."},
+  )
+
+  model_name_or_path: str = dataclasses.field(
+      metadata={"help": "MetricX model path or Hugging Face model id."},
+  )
+
+  input_dirs: list[str] = dataclasses.field(
+      metadata={
+          "help": (
+              "One or more directories containing *_result.txt files to score."
+          )
+      },
+  )
+
+  output_dir: str = dataclasses.field(
+      metadata={"help": "Directory for summary and per-file predictions."},
+  )
+
+  max_input_length: int = dataclasses.field(
+      default=1536,
+      metadata={"help": "Maximum input length for the model."},
+  )
+
+  batch_size: int = dataclasses.field(
+      default=1,
+      metadata={"help": "Global prediction batch size."},
+  )
+
+  file_pattern: str = dataclasses.field(
+      default="_result.txt",
+      metadata={"help": "Only files ending with this suffix will be scored."},
+  )
+
+  prompt_prefixes: list[str] = dataclasses.field(
+      default_factory=lambda: list(DEFAULT_PROMPT_PREFIXES),
+      metadata={
+          "help": (
+              "Optional prompt prefixes to strip from the user message before "
+              "scoring. If none match, the script falls back to taking the "
+              "text after the first colon."
+          )
+      },
+  )
+
+  qe: bool = dataclasses.field(
+      default=True,
+      metadata={"help": "Run MetricX in QE mode."},
+  )
+
+
+def _extract_source(user_content: str, prompt_prefixes: list[str]) -> str:
+  """Extracts the source text from the user prompt."""
+  for prompt_prefix in prompt_prefixes:
+    if prompt_prefix and user_content.startswith(prompt_prefix):
+      return user_content[len(prompt_prefix):].strip()
+  if "：" in user_content:
+    return user_content.split("：", 1)[1].strip()
+  if ":" in user_content:
+    return user_content.split(":", 1)[1].strip()
+  return user_content.strip()
+
+
+def _dialog_to_example(
+    dialog: list[dict[str, Any]], prompt_prefixes: list[str]
+) -> dict[str, str]:
+  """Converts one dialog line into MetricX QE input."""
+  user_turn = None
+  assistant_turn = None
+  for turn in dialog:
+    role = turn.get("role")
+    if role == "user" and user_turn is None:
+      user_turn = turn
+    elif role == "assistant" and assistant_turn is None:
+      assistant_turn = turn
+
+  if user_turn is None or assistant_turn is None:
+    raise ValueError("Each line must contain at least one user turn and one assistant turn.")
+
+  source = _extract_source(
+      str(user_turn.get("content", "")), prompt_prefixes
+  )
+  hypothesis = str(assistant_turn.get("content", "")).strip()
+
+  if not source:
+    raise ValueError("Parsed source text is empty.")
+  if not hypothesis:
+    raise ValueError("Assistant content is empty.")
+
+  return {
+      "source": source,
+      "hypothesis": hypothesis,
+      "reference": "",
+  }
+
+
+def _load_examples(
+    input_file: str, prompt_prefixes: list[str]
+) -> list[dict[str, str]]:
+  """Loads and converts a chat-style result file."""
+  examples = []
+  with open(input_file, "r", encoding="utf-8") as f:
+    for line_num, line in enumerate(f, start=1):
+      line = line.strip()
+      if not line:
+        continue
+      try:
+        dialog = json.loads(line)
+      except json.JSONDecodeError as exc:
+        raise ValueError(f"{input_file}:{line_num} is not valid JSON.") from exc
+      if not isinstance(dialog, list):
+        raise ValueError(f"{input_file}:{line_num} must be a JSON array.")
+      try:
+        examples.append(_dialog_to_example(dialog, prompt_prefixes))
+      except ValueError as exc:
+        raise ValueError(f"{input_file}:{line_num} parse failed: {exc}") from exc
+  return examples
+
+
+def _build_dataset(
+    examples: list[dict[str, str]],
+    tokenizer,
+    max_input_length: int,
+    device,
+    is_qe: bool,
+):
+  """Builds a tokenized dataset compatible with Trainer.predict."""
+
+  def _make_input(example):
+    if is_qe:
+      example["input"] = (
+          "source: "
+          + example["source"]
+          + " candidate: "
+          + example["hypothesis"]
+      )
+    else:
+      example["input"] = (
+          "source: "
+          + example["source"]
+          + " candidate: "
+          + example["hypothesis"]
+          + " reference: "
+          + example["reference"]
+      )
+    return example
+
+  def _tokenize(example):
+    return tokenizer(
+        example["input"],
+        max_length=max_input_length,
+        truncation=True,
+        padding=False,
+    )
+
+  def _remove_eos(example):
+    example["input_ids"] = example["input_ids"][:-1]
+    example["attention_mask"] = example["attention_mask"][:-1]
+    return example
+
+  ds = datasets.Dataset.from_list(examples)
+  ds = ds.map(_make_input)
+  ds = ds.map(_tokenize)
+  ds = ds.map(_remove_eos)
+  ds.set_format(
+      type="torch",
+      columns=["input_ids", "attention_mask"],
+      device=device,
+      output_all_columns=True,
+  )
+  return ds
+
+
+def _get_input_files(input_dirs: list[str], file_pattern: str) -> list[str]:
+  """Collects files to score."""
+  input_files = []
+  for input_dir in input_dirs:
+    for entry in sorted(os.listdir(input_dir)):
+      if entry.endswith(file_pattern):
+        input_files.append(os.path.join(input_dir, entry))
+  return input_files
+
+
+def _detail_filename(input_file: str) -> str:
+  parent = os.path.basename(os.path.dirname(input_file))
+  return f"{parent}__{os.path.basename(input_file)}.jsonl"
+
+
+def main() -> None:
+  parser = transformers.HfArgumentParser(Arguments)
+  (args,) = parser.parse_args_into_dataclasses()
+
+  os.makedirs(args.output_dir, exist_ok=True)
+  details_dir = os.path.join(args.output_dir, "details")
+  os.makedirs(details_dir, exist_ok=True)
+
+  if torch.cuda.is_available():
+    device = torch.device("cuda")
+    per_device_batch_size = max(1, args.batch_size // torch.cuda.device_count())
+  else:
+    device = torch.device("cpu")
+    per_device_batch_size = args.batch_size
+
+  tokenizer = transformers.AutoTokenizer.from_pretrained(args.tokenizer)
+  model = models.MT5ForRegression.from_pretrained(
+      args.model_name_or_path, torch_dtype="auto"
+  )
+  model.to(device)
+  model.eval()
+
+  training_args = transformers.TrainingArguments(
+      output_dir=args.output_dir,
+      per_device_eval_batch_size=per_device_batch_size,
+      dataloader_pin_memory=False,
+  )
+  trainer = transformers.Trainer(
+      model=model,
+      args=training_args,
+  )
+
+  summary = []
+  summary_by_dir = {}
+  input_files = _get_input_files(args.input_dirs, args.file_pattern)
+  if not input_files:
+    raise ValueError("No input files matched the given directories and file pattern.")
+
+  for input_file in input_files:
+    examples = _load_examples(input_file, args.prompt_prefixes)
+    ds = _build_dataset(
+        examples,
+        tokenizer,
+        args.max_input_length,
+        device,
+        args.qe,
+    )
+    predictions, _, _ = trainer.predict(test_dataset=ds)
+    scores = np.asarray(predictions, dtype=float).reshape(-1)
+
+    detail_path = os.path.join(details_dir, _detail_filename(input_file))
+    with open(detail_path, "w", encoding="utf-8") as out:
+      for example, score in zip(examples, scores):
+        record = dict(example)
+        record["prediction"] = float(score)
+        out.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    item = {
+        "input_file": input_file,
+        "input_dir": os.path.dirname(input_file),
+        "num_examples": len(examples),
+        "mean_score": float(np.mean(scores)),
+        "median_score": float(np.median(scores)),
+        "min_score": float(np.min(scores)),
+        "max_score": float(np.max(scores)),
+        "detail_file": detail_path,
+    }
+    summary.append(item)
+
+    input_dir = item["input_dir"]
+    if input_dir not in summary_by_dir:
+      summary_by_dir[input_dir] = {
+          "input_dir": input_dir,
+          "num_files": 0,
+          "num_examples": 0,
+          "weighted_score_sum": 0.0,
+      }
+    summary_by_dir[input_dir]["num_files"] += 1
+    summary_by_dir[input_dir]["num_examples"] += item["num_examples"]
+    summary_by_dir[input_dir]["weighted_score_sum"] += (
+        item["mean_score"] * item["num_examples"]
+    )
+
+  summary_path = os.path.join(args.output_dir, "summary.json")
+  with open(summary_path, "w", encoding="utf-8") as out:
+    json.dump(summary, out, ensure_ascii=False, indent=2)
+
+  summary_by_dir_path = os.path.join(args.output_dir, "summary_by_dir.json")
+  summary_by_dir_items = []
+  for item in summary_by_dir.values():
+    item["mean_score"] = item["weighted_score_sum"] / item["num_examples"]
+    del item["weighted_score_sum"]
+    summary_by_dir_items.append(item)
+  with open(summary_by_dir_path, "w", encoding="utf-8") as out:
+    json.dump(summary_by_dir_items, out, ensure_ascii=False, indent=2)
+
+  for item in summary:
+    print(
+        json.dumps(
+            {
+                "input_file": item["input_file"],
+                "num_examples": item["num_examples"],
+                "mean_score": item["mean_score"],
+            },
+            ensure_ascii=False,
+        )
+    )
+  print(f"Saved summary to {summary_path}")
+  print(f"Saved directory summary to {summary_by_dir_path}")
+
+
+if __name__ == "__main__":
+  main()

--- a/metricx24/score_dialog_outputs.py
+++ b/metricx24/score_dialog_outputs.py
@@ -32,15 +32,18 @@ DEFAULT_PROMPT_PREFIXES = [
 
 @dataclasses.dataclass
 class Arguments:
-  tokenizer: str = dataclasses.field(
+  tokenizer: str | None = dataclasses.field(
+      default=None,
       metadata={"help": "The tokenizer name."},
   )
 
-  model_name_or_path: str = dataclasses.field(
+  model_name_or_path: str | None = dataclasses.field(
+      default=None,
       metadata={"help": "MetricX model path or Hugging Face model id."},
   )
 
   input_dirs: list[str] = dataclasses.field(
+      default_factory=list,
       metadata={
           "help": (
               "One or more directories containing *_result.txt files to score."
@@ -81,6 +84,21 @@ class Arguments:
   qe: bool = dataclasses.field(
       default=True,
       metadata={"help": "Run MetricX in QE mode."},
+  )
+
+  shard_index: int = dataclasses.field(
+      default=0,
+      metadata={"help": "Current shard index, 0-based."},
+  )
+
+  num_shards: int = dataclasses.field(
+      default=1,
+      metadata={"help": "Total number of shards."},
+  )
+
+  merge_only: bool = dataclasses.field(
+      default=False,
+      metadata={"help": "Only merge shard partial summaries."},
   )
 
 
@@ -221,6 +239,89 @@ def _detail_filename(input_file: str) -> str:
   return f"{parent}__{os.path.basename(input_file)}.jsonl"
 
 
+def _shard_input_files(
+    input_files: list[str], shard_index: int, num_shards: int
+) -> list[str]:
+  return [
+      input_file
+      for idx, input_file in enumerate(input_files)
+      if idx % num_shards == shard_index
+  ]
+
+
+def _partials_dir(output_dir: str) -> str:
+  return os.path.join(output_dir, "partials")
+
+
+def _partial_summary_path(
+    output_dir: str, shard_index: int, num_shards: int
+) -> str:
+  filename = f"summary_shard_{shard_index:05d}_of_{num_shards:05d}.json"
+  return os.path.join(_partials_dir(output_dir), filename)
+
+
+def _write_json(output_file: str, payload: Any) -> None:
+  dirname = os.path.dirname(output_file)
+  if dirname:
+    os.makedirs(dirname, exist_ok=True)
+  with open(output_file, "w", encoding="utf-8") as out:
+    json.dump(payload, out, ensure_ascii=False, indent=2)
+
+
+def _summarize_by_dir(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+  summary_by_dir = {}
+  for item in summary:
+    input_dir = item["input_dir"]
+    if input_dir not in summary_by_dir:
+      summary_by_dir[input_dir] = {
+          "input_dir": input_dir,
+          "num_files": 0,
+          "num_examples": 0,
+          "weighted_score_sum": 0.0,
+      }
+    summary_by_dir[input_dir]["num_files"] += 1
+    summary_by_dir[input_dir]["num_examples"] += item["num_examples"]
+    summary_by_dir[input_dir]["weighted_score_sum"] += (
+        item["mean_score"] * item["num_examples"]
+    )
+
+  summary_by_dir_items = []
+  for item in summary_by_dir.values():
+    item["mean_score"] = item["weighted_score_sum"] / item["num_examples"]
+    del item["weighted_score_sum"]
+    summary_by_dir_items.append(item)
+  return sorted(summary_by_dir_items, key=lambda item: item["input_dir"])
+
+
+def _write_final_summaries(output_dir: str, summary: list[dict[str, Any]]) -> None:
+  summary = sorted(summary, key=lambda item: item["input_file"])
+  summary_path = os.path.join(output_dir, "summary.json")
+  summary_by_dir_path = os.path.join(output_dir, "summary_by_dir.json")
+  _write_json(summary_path, summary)
+  _write_json(summary_by_dir_path, _summarize_by_dir(summary))
+  print(f"Saved summary to {summary_path}")
+  print(f"Saved directory summary to {summary_by_dir_path}")
+
+
+def _merge_partial_summaries(output_dir: str, num_shards: int) -> None:
+  merged_summary = []
+  missing = []
+  for shard_index in range(num_shards):
+    partial_path = _partial_summary_path(output_dir, shard_index, num_shards)
+    if not os.path.exists(partial_path):
+      missing.append(partial_path)
+      continue
+    with open(partial_path, "r", encoding="utf-8") as f:
+      merged_summary.extend(json.load(f))
+
+  if missing:
+    raise ValueError(
+        "Missing shard partial summaries: " + ", ".join(missing)
+    )
+
+  _write_final_summaries(output_dir, merged_summary)
+
+
 def main() -> None:
   parser = transformers.HfArgumentParser(Arguments)
   (args,) = parser.parse_args_into_dataclasses()
@@ -229,9 +330,27 @@ def main() -> None:
   details_dir = os.path.join(args.output_dir, "details")
   os.makedirs(details_dir, exist_ok=True)
 
+  if args.num_shards < 1:
+    raise ValueError("--num_shards must be at least 1.")
+  if args.shard_index < 0 or args.shard_index >= args.num_shards:
+    raise ValueError("--shard_index must be in [0, num_shards).")
+
+  if args.merge_only:
+    _merge_partial_summaries(args.output_dir, args.num_shards)
+    return
+
+  if not args.tokenizer:
+    raise ValueError("--tokenizer is required unless --merge_only is set.")
+  if not args.model_name_or_path:
+    raise ValueError(
+        "--model_name_or_path is required unless --merge_only is set."
+    )
+  if not args.input_dirs:
+    raise ValueError("--input_dirs is required unless --merge_only is set.")
+
   if torch.cuda.is_available():
     device = torch.device("cuda")
-    per_device_batch_size = max(1, args.batch_size // torch.cuda.device_count())
+    per_device_batch_size = args.batch_size
   else:
     device = torch.device("cpu")
     per_device_batch_size = args.batch_size
@@ -255,10 +374,14 @@ def main() -> None:
   )
 
   summary = []
-  summary_by_dir = {}
   input_files = _get_input_files(args.input_dirs, args.file_pattern)
   if not input_files:
     raise ValueError("No input files matched the given directories and file pattern.")
+  input_files = _shard_input_files(input_files, args.shard_index, args.num_shards)
+  print(
+      f"Shard {args.shard_index}/{args.num_shards} processing "
+      f"{len(input_files)} files."
+  )
 
   for input_file in input_files:
     examples = _load_examples(input_file, args.prompt_prefixes)
@@ -290,33 +413,10 @@ def main() -> None:
         "detail_file": detail_path,
     }
     summary.append(item)
-
-    input_dir = item["input_dir"]
-    if input_dir not in summary_by_dir:
-      summary_by_dir[input_dir] = {
-          "input_dir": input_dir,
-          "num_files": 0,
-          "num_examples": 0,
-          "weighted_score_sum": 0.0,
-      }
-    summary_by_dir[input_dir]["num_files"] += 1
-    summary_by_dir[input_dir]["num_examples"] += item["num_examples"]
-    summary_by_dir[input_dir]["weighted_score_sum"] += (
-        item["mean_score"] * item["num_examples"]
-    )
-
-  summary_path = os.path.join(args.output_dir, "summary.json")
-  with open(summary_path, "w", encoding="utf-8") as out:
-    json.dump(summary, out, ensure_ascii=False, indent=2)
-
-  summary_by_dir_path = os.path.join(args.output_dir, "summary_by_dir.json")
-  summary_by_dir_items = []
-  for item in summary_by_dir.values():
-    item["mean_score"] = item["weighted_score_sum"] / item["num_examples"]
-    del item["weighted_score_sum"]
-    summary_by_dir_items.append(item)
-  with open(summary_by_dir_path, "w", encoding="utf-8") as out:
-    json.dump(summary_by_dir_items, out, ensure_ascii=False, indent=2)
+  partial_summary_path = _partial_summary_path(
+      args.output_dir, args.shard_index, args.num_shards
+  )
+  _write_json(partial_summary_path, summary)
 
   for item in summary:
     print(
@@ -329,8 +429,10 @@ def main() -> None:
             ensure_ascii=False,
         )
     )
-  print(f"Saved summary to {summary_path}")
-  print(f"Saved directory summary to {summary_by_dir_path}")
+  print(f"Saved shard summary to {partial_summary_path}")
+
+  if args.num_shards == 1:
+    _write_final_summaries(args.output_dir, summary)
 
 
 if __name__ == "__main__":

--- a/metricx24/score_dialog_outputs.py
+++ b/metricx24/score_dialog_outputs.py
@@ -101,6 +101,21 @@ class Arguments:
       metadata={"help": "Only merge shard partial summaries."},
   )
 
+  preprocessing_num_workers: int = dataclasses.field(
+      default=4,
+      metadata={"help": "Number of worker processes for dataset.map."},
+  )
+
+  dataloader_num_workers: int = dataclasses.field(
+      default=4,
+      metadata={"help": "Number of worker processes for the dataloader."},
+  )
+
+  bf16: bool = dataclasses.field(
+      default=False,
+      metadata={"help": "Load and run the model in bfloat16 on supported GPUs."},
+  )
+
 
 def _extract_source(user_content: str, prompt_prefixes: list[str]) -> str:
   """Extracts the source text from the user prompt."""
@@ -174,10 +189,11 @@ def _build_dataset(
     examples: list[dict[str, str]],
     tokenizer,
     max_input_length: int,
-    device,
     is_qe: bool,
+    preprocessing_num_workers: int,
 ):
   """Builds a tokenized dataset compatible with Trainer.predict."""
+  preprocessing_num_workers = max(1, preprocessing_num_workers)
 
   def _make_input(example):
     if is_qe:
@@ -212,13 +228,13 @@ def _build_dataset(
     return example
 
   ds = datasets.Dataset.from_list(examples)
-  ds = ds.map(_make_input)
-  ds = ds.map(_tokenize)
-  ds = ds.map(_remove_eos)
+  map_kwargs = {"num_proc": preprocessing_num_workers}
+  ds = ds.map(_make_input, **map_kwargs)
+  ds = ds.map(_tokenize, **map_kwargs)
+  ds = ds.map(_remove_eos, **map_kwargs)
   ds.set_format(
       type="torch",
       columns=["input_ids", "attention_mask"],
-      device=device,
       output_all_columns=True,
   )
   return ds
@@ -242,11 +258,18 @@ def _detail_filename(input_file: str) -> str:
 def _shard_input_files(
     input_files: list[str], shard_index: int, num_shards: int
 ) -> list[str]:
-  return [
-      input_file
-      for idx, input_file in enumerate(input_files)
-      if idx % num_shards == shard_index
-  ]
+  sorted_files = sorted(
+      input_files,
+      key=lambda input_file: os.path.getsize(input_file),
+      reverse=True,
+  )
+  shards = [[] for _ in range(num_shards)]
+  shard_sizes = [0 for _ in range(num_shards)]
+  for input_file in sorted_files:
+    target_shard = min(range(num_shards), key=lambda idx: shard_sizes[idx])
+    shards[target_shard].append(input_file)
+    shard_sizes[target_shard] += os.path.getsize(input_file)
+  return sorted(shards[shard_index])
 
 
 def _partials_dir(output_dir: str) -> str:
@@ -356,8 +379,11 @@ def main() -> None:
     per_device_batch_size = args.batch_size
 
   tokenizer = transformers.AutoTokenizer.from_pretrained(args.tokenizer)
+  model_dtype = (
+      torch.bfloat16 if args.bf16 and torch.cuda.is_available() else "auto"
+  )
   model = models.MT5ForRegression.from_pretrained(
-      args.model_name_or_path, torch_dtype="auto"
+      args.model_name_or_path, torch_dtype=model_dtype
   )
   model.to(device)
   model.eval()
@@ -365,7 +391,9 @@ def main() -> None:
   training_args = transformers.TrainingArguments(
       output_dir=args.output_dir,
       per_device_eval_batch_size=per_device_batch_size,
-      dataloader_pin_memory=False,
+      dataloader_pin_memory=torch.cuda.is_available(),
+      dataloader_num_workers=args.dataloader_num_workers,
+      bf16=args.bf16 and torch.cuda.is_available(),
   )
   trainer = transformers.Trainer(
       model=model,
@@ -389,8 +417,8 @@ def main() -> None:
         examples,
         tokenizer,
         args.max_input_length,
-        device,
         args.qe,
+        args.preprocessing_num_workers,
     )
     predictions, _, _ = trainer.predict(test_dataset=ds)
     scores = np.asarray(predictions, dtype=float).reshape(-1)

--- a/metricx24/score_dialog_outputs.py
+++ b/metricx24/score_dialog_outputs.py
@@ -145,10 +145,10 @@ def _dialog_to_example(
   if user_turn is None or assistant_turn is None:
     raise ValueError("Each line must contain at least one user turn and one assistant turn.")
 
-  source = _extract_source(
-      str(user_turn.get("content", "")), prompt_prefixes
-  )
-  hypothesis = str(assistant_turn.get("content", "")).strip()
+  original_source = str(user_turn.get("content", ""))
+  original_hypothesis = str(assistant_turn.get("content", "")).strip()
+  source = _extract_source(original_source, prompt_prefixes)
+  hypothesis = original_hypothesis
 
   if not source:
     raise ValueError("Parsed source text is empty.")
@@ -159,6 +159,7 @@ def _dialog_to_example(
       "source": source,
       "hypothesis": hypothesis,
       "reference": "",
+      "original_source": original_source,
   }
 
 
@@ -503,7 +504,11 @@ def main() -> None:
 
     detail_rows = []
     for example, score in zip(examples, scores):
-      record = dict(example)
+      record = {
+          "source": example["original_source"],
+          "hypothesis": example["hypothesis"],
+          "reference": example["reference"],
+      }
       record["prediction"] = float(score)
       detail_rows.append(record)
     _write_jsonl(detail_path, detail_rows)

--- a/metricx24/score_dialog_outputs.py
+++ b/metricx24/score_dialog_outputs.py
@@ -32,6 +32,10 @@ DEFAULT_PROMPT_PREFIXES = [
 
 @dataclasses.dataclass
 class Arguments:
+  output_dir: str = dataclasses.field(
+      metadata={"help": "Directory for summary and per-file predictions."},
+  )
+
   tokenizer: str | None = dataclasses.field(
       default=None,
       metadata={"help": "The tokenizer name."},
@@ -49,10 +53,6 @@ class Arguments:
               "One or more directories containing *_result.txt files to score."
           )
       },
-  )
-
-  output_dir: str = dataclasses.field(
-      metadata={"help": "Directory for summary and per-file predictions."},
   )
 
   max_input_length: int = dataclasses.field(

--- a/metricx24/score_dialog_outputs.py
+++ b/metricx24/score_dialog_outputs.py
@@ -164,9 +164,10 @@ def _dialog_to_example(
 
 def _load_examples(
     input_file: str, prompt_prefixes: list[str]
-) -> list[dict[str, str]]:
+) -> tuple[list[dict[str, str]], list[dict[str, Any]]]:
   """Loads and converts a chat-style result file."""
   examples = []
+  bad_rows = []
   with open(input_file, "r", encoding="utf-8") as f:
     for line_num, line in enumerate(f, start=1):
       line = line.strip()
@@ -181,8 +182,13 @@ def _load_examples(
       try:
         examples.append(_dialog_to_example(dialog, prompt_prefixes))
       except ValueError as exc:
-        raise ValueError(f"{input_file}:{line_num} parse failed: {exc}") from exc
-  return examples
+        bad_rows.append({
+            "input_file": input_file,
+            "line_num": line_num,
+            "error": str(exc),
+            "raw_line": line,
+        })
+  return examples, bad_rows
 
 
 def _build_dataset(
@@ -255,6 +261,15 @@ def _detail_filename(input_file: str) -> str:
   return f"{parent}__{os.path.basename(input_file)}.jsonl"
 
 
+def _bad_rows_filename(input_file: str) -> str:
+  parent = os.path.basename(os.path.dirname(input_file))
+  return f"{parent}__{os.path.basename(input_file)}.bad_rows.jsonl"
+
+
+def _tmp_path(output_file: str) -> str:
+  return output_file + ".tmp"
+
+
 def _shard_input_files(
     input_files: list[str], shard_index: int, num_shards: int
 ) -> list[str]:
@@ -287,8 +302,25 @@ def _write_json(output_file: str, payload: Any) -> None:
   dirname = os.path.dirname(output_file)
   if dirname:
     os.makedirs(dirname, exist_ok=True)
-  with open(output_file, "w", encoding="utf-8") as out:
+  tmp_output_file = _tmp_path(output_file)
+  with open(tmp_output_file, "w", encoding="utf-8") as out:
     json.dump(payload, out, ensure_ascii=False, indent=2)
+  os.replace(tmp_output_file, output_file)
+
+
+def _write_jsonl(output_file: str, rows: list[dict[str, Any]]) -> None:
+  dirname = os.path.dirname(output_file)
+  if dirname:
+    os.makedirs(dirname, exist_ok=True)
+  tmp_output_file = _tmp_path(output_file)
+  with open(tmp_output_file, "w", encoding="utf-8") as out:
+    for row in rows:
+      out.write(json.dumps(row, ensure_ascii=False) + "\n")
+  os.replace(tmp_output_file, output_file)
+
+
+def _is_completed_output(output_file: str) -> bool:
+  return os.path.exists(output_file) and not os.path.exists(_tmp_path(output_file))
 
 
 def _summarize_by_dir(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -314,6 +346,34 @@ def _summarize_by_dir(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
     del item["weighted_score_sum"]
     summary_by_dir_items.append(item)
   return sorted(summary_by_dir_items, key=lambda item: item["input_dir"])
+
+
+def _summary_item_from_detail_file(
+    input_file: str, detail_file: str
+) -> dict[str, Any]:
+  scores = []
+  with open(detail_file, "r", encoding="utf-8") as f:
+    for line in f:
+      line = line.strip()
+      if not line:
+        continue
+      record = json.loads(line)
+      scores.append(float(record["prediction"]))
+
+  if not scores:
+    raise ValueError(f"Completed detail file {detail_file} is empty.")
+
+  score_array = np.asarray(scores, dtype=float)
+  return {
+      "input_file": input_file,
+      "input_dir": os.path.dirname(input_file),
+      "num_examples": len(score_array),
+      "mean_score": float(np.mean(score_array)),
+      "median_score": float(np.median(score_array)),
+      "min_score": float(np.min(score_array)),
+      "max_score": float(np.max(score_array)),
+      "detail_file": detail_file,
+  }
 
 
 def _write_final_summaries(output_dir: str, summary: list[dict[str, Any]]) -> None:
@@ -352,6 +412,8 @@ def main() -> None:
   os.makedirs(args.output_dir, exist_ok=True)
   details_dir = os.path.join(args.output_dir, "details")
   os.makedirs(details_dir, exist_ok=True)
+  bad_rows_dir = os.path.join(args.output_dir, "bad_rows")
+  os.makedirs(bad_rows_dir, exist_ok=True)
 
   if args.num_shards < 1:
     raise ValueError("--num_shards must be at least 1.")
@@ -412,7 +474,23 @@ def main() -> None:
   )
 
   for input_file in input_files:
-    examples = _load_examples(input_file, args.prompt_prefixes)
+    detail_path = os.path.join(details_dir, _detail_filename(input_file))
+    if _is_completed_output(detail_path):
+      print(f"Skipping completed file {input_file} because {detail_path} already exists.")
+      summary.append(_summary_item_from_detail_file(input_file, detail_path))
+      continue
+
+    examples, bad_rows = _load_examples(input_file, args.prompt_prefixes)
+    if bad_rows:
+      bad_rows_path = os.path.join(bad_rows_dir, _bad_rows_filename(input_file))
+      _write_jsonl(bad_rows_path, bad_rows)
+      print(
+          f"Skipped {len(bad_rows)} bad rows from {input_file}; "
+          f"details saved to {bad_rows_path}"
+      )
+    if not examples:
+      print(f"Skipping {input_file} because no valid examples remain after filtering.")
+      continue
     ds = _build_dataset(
         examples,
         tokenizer,
@@ -423,23 +501,14 @@ def main() -> None:
     predictions, _, _ = trainer.predict(test_dataset=ds)
     scores = np.asarray(predictions, dtype=float).reshape(-1)
 
-    detail_path = os.path.join(details_dir, _detail_filename(input_file))
-    with open(detail_path, "w", encoding="utf-8") as out:
-      for example, score in zip(examples, scores):
-        record = dict(example)
-        record["prediction"] = float(score)
-        out.write(json.dumps(record, ensure_ascii=False) + "\n")
+    detail_rows = []
+    for example, score in zip(examples, scores):
+      record = dict(example)
+      record["prediction"] = float(score)
+      detail_rows.append(record)
+    _write_jsonl(detail_path, detail_rows)
 
-    item = {
-        "input_file": input_file,
-        "input_dir": os.path.dirname(input_file),
-        "num_examples": len(examples),
-        "mean_score": float(np.mean(scores)),
-        "median_score": float(np.median(scores)),
-        "min_score": float(np.min(scores)),
-        "max_score": float(np.max(scores)),
-        "detail_file": detail_path,
-    }
+    item = _summary_item_from_detail_file(input_file, detail_path)
     summary.append(item)
   partial_summary_path = _partial_summary_path(
       args.output_dir, args.shard_index, args.num_shards

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 transformers[torch]==4.30.2
 sentencepiece==0.1.99
 datasets==2.13.1
-git+https://github.com/google-research/mt-metrics-eval

--- a/run_metricx_score_v3_r1.sh
+++ b/run_metricx_score_v3_r1.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+HF_CACHE_ROOT="${HF_CACHE_ROOT:-/llm-align/liuchonghan/hf_cache}"
+MODEL_SNAPSHOT="${MODEL_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--metricx-24-hybrid-xl-v2p6/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
+TOKENIZER_SNAPSHOT="${TOKENIZER_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--mt5-xl/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
+
+OUTPUT_DIR="${OUTPUT_DIR:-/llm-align/liuchonghan/metricx_scores_v3_r1}"
+BATCH_SIZE="${BATCH_SIZE:-128}"
+MAX_INPUT_LENGTH="${MAX_INPUT_LENGTH:-1536}"
+LOG_FILE="${LOG_FILE:-/llm-align/liuchonghan/metricx_scores_v3_r1_run.log}"
+
+INPUT_DIR_1="${INPUT_DIR_1:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_1}"
+INPUT_DIR_2="${INPUT_DIR_2:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_2_t0.9}"
+INPUT_DIR_3="${INPUT_DIR_3:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_3_t0.9}"
+
+if [[ -z "$MODEL_SNAPSHOT" || ! -d "$MODEL_SNAPSHOT" ]]; then
+  echo "MetricX model snapshot not found under $HF_CACHE_ROOT" >&2
+  exit 1
+fi
+
+if [[ -z "$TOKENIZER_SNAPSHOT" || ! -d "$TOKENIZER_SNAPSHOT" ]]; then
+  echo "mT5 tokenizer snapshot not found under $HF_CACHE_ROOT" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+cd "$REPO_DIR"
+
+echo "repo_dir=$REPO_DIR"
+echo "model_snapshot=$MODEL_SNAPSHOT"
+echo "tokenizer_snapshot=$TOKENIZER_SNAPSHOT"
+echo "output_dir=$OUTPUT_DIR"
+echo "batch_size=$BATCH_SIZE"
+echo "max_input_length=$MAX_INPUT_LENGTH"
+echo "log_file=$LOG_FILE"
+echo "input_dirs:"
+echo "  $INPUT_DIR_1"
+echo "  $INPUT_DIR_2"
+echo "  $INPUT_DIR_3"
+
+nohup python3 -m metricx24.score_dialog_outputs \
+  --tokenizer "$TOKENIZER_SNAPSHOT" \
+  --model_name_or_path "$MODEL_SNAPSHOT" \
+  --input_dirs "$INPUT_DIR_1" "$INPUT_DIR_2" "$INPUT_DIR_3" \
+  --output_dir "$OUTPUT_DIR" \
+  --batch_size "$BATCH_SIZE" \
+  --max_input_length "$MAX_INPUT_LENGTH" \
+  --qe > "$LOG_FILE" 2>&1 &
+
+PID=$!
+echo "started_pid=$PID"
+echo "tail_log=tail -f $LOG_FILE"
+echo "summary_file=$OUTPUT_DIR/summary_by_dir.json"

--- a/run_metricx_score_v3_r1.sh
+++ b/run_metricx_score_v3_r1.sh
@@ -8,7 +8,7 @@ MODEL_SNAPSHOT="${MODEL_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--metricx
 TOKENIZER_SNAPSHOT="${TOKENIZER_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--mt5-xl/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
 
 OUTPUT_DIR="${OUTPUT_DIR:-/llm-align/liuchonghan/metricx_result}"
-BATCH_SIZE="${BATCH_SIZE:-64}"
+BATCH_SIZE="${BATCH_SIZE:-32}"
 MAX_INPUT_LENGTH="${MAX_INPUT_LENGTH:-1024}"
 NUM_GPUS="${NUM_GPUS:-8}"
 PREPROCESSING_NUM_WORKERS="${PREPROCESSING_NUM_WORKERS:-8}"

--- a/run_metricx_score_v3_r1.sh
+++ b/run_metricx_score_v3_r1.sh
@@ -7,9 +7,10 @@ HF_CACHE_ROOT="${HF_CACHE_ROOT:-/llm-align/liuchonghan/hf_cache}"
 MODEL_SNAPSHOT="${MODEL_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--metricx-24-hybrid-xl-v2p6/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
 TOKENIZER_SNAPSHOT="${TOKENIZER_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--mt5-xl/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
 
-OUTPUT_DIR="${OUTPUT_DIR:-/llm-align/liuchonghan/metricx_scores_v3_r1}"
-BATCH_SIZE="${BATCH_SIZE:-128}"
-MAX_INPUT_LENGTH="${MAX_INPUT_LENGTH:-1536}"
+OUTPUT_DIR="${OUTPUT_DIR:-/llm-align/liuchonghan/metricx_result}"
+BATCH_SIZE="${BATCH_SIZE:-256}"
+MAX_INPUT_LENGTH="${MAX_INPUT_LENGTH:-1024}"
+NUM_GPUS="${NUM_GPUS:-8}"
 
 INPUT_DIR_1="${INPUT_DIR_1:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_1}"
 INPUT_DIR_2="${INPUT_DIR_2:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_2_t0.9}"
@@ -26,6 +27,7 @@ if [[ -z "$TOKENIZER_SNAPSHOT" || ! -d "$TOKENIZER_SNAPSHOT" ]]; then
 fi
 
 mkdir -p "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/logs"
 
 cd "$REPO_DIR"
 
@@ -35,17 +37,36 @@ echo "tokenizer_snapshot=$TOKENIZER_SNAPSHOT"
 echo "output_dir=$OUTPUT_DIR"
 echo "batch_size=$BATCH_SIZE"
 echo "max_input_length=$MAX_INPUT_LENGTH"
+echo "num_gpus=$NUM_GPUS"
 echo "input_dirs:"
 echo "  $INPUT_DIR_1"
 echo "  $INPUT_DIR_2"
 echo "  $INPUT_DIR_3"
 
+PIDS=()
+for ((SHARD_INDEX=0; SHARD_INDEX<NUM_GPUS; SHARD_INDEX++)); do
+  LOG_FILE="$OUTPUT_DIR/logs/shard_${SHARD_INDEX}.log"
+  echo "starting shard=$SHARD_INDEX log_file=$LOG_FILE"
+  CUDA_VISIBLE_DEVICES="$SHARD_INDEX" python3 -m metricx24.score_dialog_outputs \
+    --tokenizer "$TOKENIZER_SNAPSHOT" \
+    --model_name_or_path "$MODEL_SNAPSHOT" \
+    --input_dirs "$INPUT_DIR_1" "$INPUT_DIR_2" "$INPUT_DIR_3" \
+    --output_dir "$OUTPUT_DIR" \
+    --batch_size "$BATCH_SIZE" \
+    --max_input_length "$MAX_INPUT_LENGTH" \
+    --num_shards "$NUM_GPUS" \
+    --shard_index "$SHARD_INDEX" \
+    --qe > "$LOG_FILE" 2>&1 &
+  PIDS+=("$!")
+done
+
+for PID in "${PIDS[@]}"; do
+  wait "$PID"
+done
+
 python3 -m metricx24.score_dialog_outputs \
-  --tokenizer "$TOKENIZER_SNAPSHOT" \
-  --model_name_or_path "$MODEL_SNAPSHOT" \
-  --input_dirs "$INPUT_DIR_1" "$INPUT_DIR_2" "$INPUT_DIR_3" \
   --output_dir "$OUTPUT_DIR" \
-  --batch_size "$BATCH_SIZE" \
-  --max_input_length "$MAX_INPUT_LENGTH" \
-  --qe
+  --num_shards "$NUM_GPUS" \
+  --merge_only
+
 echo "summary_file=$OUTPUT_DIR/summary_by_dir.json"

--- a/run_metricx_score_v3_r1.sh
+++ b/run_metricx_score_v3_r1.sh
@@ -10,7 +10,6 @@ TOKENIZER_SNAPSHOT="${TOKENIZER_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google-
 OUTPUT_DIR="${OUTPUT_DIR:-/llm-align/liuchonghan/metricx_scores_v3_r1}"
 BATCH_SIZE="${BATCH_SIZE:-128}"
 MAX_INPUT_LENGTH="${MAX_INPUT_LENGTH:-1536}"
-LOG_FILE="${LOG_FILE:-/llm-align/liuchonghan/metricx_scores_v3_r1_run.log}"
 
 INPUT_DIR_1="${INPUT_DIR_1:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_1}"
 INPUT_DIR_2="${INPUT_DIR_2:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_2_t0.9}"
@@ -27,7 +26,6 @@ if [[ -z "$TOKENIZER_SNAPSHOT" || ! -d "$TOKENIZER_SNAPSHOT" ]]; then
 fi
 
 mkdir -p "$OUTPUT_DIR"
-mkdir -p "$(dirname "$LOG_FILE")"
 
 cd "$REPO_DIR"
 
@@ -37,22 +35,17 @@ echo "tokenizer_snapshot=$TOKENIZER_SNAPSHOT"
 echo "output_dir=$OUTPUT_DIR"
 echo "batch_size=$BATCH_SIZE"
 echo "max_input_length=$MAX_INPUT_LENGTH"
-echo "log_file=$LOG_FILE"
 echo "input_dirs:"
 echo "  $INPUT_DIR_1"
 echo "  $INPUT_DIR_2"
 echo "  $INPUT_DIR_3"
 
-nohup python3 -m metricx24.score_dialog_outputs \
+python3 -m metricx24.score_dialog_outputs \
   --tokenizer "$TOKENIZER_SNAPSHOT" \
   --model_name_or_path "$MODEL_SNAPSHOT" \
   --input_dirs "$INPUT_DIR_1" "$INPUT_DIR_2" "$INPUT_DIR_3" \
   --output_dir "$OUTPUT_DIR" \
   --batch_size "$BATCH_SIZE" \
   --max_input_length "$MAX_INPUT_LENGTH" \
-  --qe > "$LOG_FILE" 2>&1 &
-
-PID=$!
-echo "started_pid=$PID"
-echo "tail_log=tail -f $LOG_FILE"
+  --qe
 echo "summary_file=$OUTPUT_DIR/summary_by_dir.json"

--- a/run_metricx_score_v3_r1.sh
+++ b/run_metricx_score_v3_r1.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 HF_CACHE_ROOT="${HF_CACHE_ROOT:-/llm-align/liuchonghan/hf_cache}"
-MODEL_SNAPSHOT="${MODEL_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--metricx-24-hybrid-xl-v2p6/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
+MODEL_SNAPSHOT="${MODEL_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--metricx-24-hybrid-xxl-v2p6/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
 TOKENIZER_SNAPSHOT="${TOKENIZER_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--mt5-xl/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
 
 OUTPUT_DIR="${OUTPUT_DIR:-/llm-align/liuchonghan/metricx_result}"
-BATCH_SIZE="${BATCH_SIZE:-128}"
+BATCH_SIZE="${BATCH_SIZE:-64}"
 MAX_INPUT_LENGTH="${MAX_INPUT_LENGTH:-1024}"
 NUM_GPUS="${NUM_GPUS:-8}"
 PREPROCESSING_NUM_WORKERS="${PREPROCESSING_NUM_WORKERS:-8}"
@@ -18,6 +18,8 @@ USE_BF16="${USE_BF16:-1}"
 INPUT_DIR_1="${INPUT_DIR_1:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_1}"
 INPUT_DIR_2="${INPUT_DIR_2:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_2_t0.9}"
 INPUT_DIR_3="${INPUT_DIR_3:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_3_t0.9}"
+INPUT_DIR_4="${INPUT_DIR_4:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_4_t0.9}"
+INPUT_DIR_5="${INPUT_DIR_5:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_5_t0.9}"
 
 if [[ -z "$MODEL_SNAPSHOT" || ! -d "$MODEL_SNAPSHOT" ]]; then
   echo "MetricX model snapshot not found under $HF_CACHE_ROOT" >&2
@@ -48,6 +50,8 @@ echo "input_dirs:"
 echo "  $INPUT_DIR_1"
 echo "  $INPUT_DIR_2"
 echo "  $INPUT_DIR_3"
+echo "  $INPUT_DIR_4"
+echo "  $INPUT_DIR_5"
 
 EXTRA_ARGS=()
 if [[ "$USE_BF16" == "1" ]]; then
@@ -61,7 +65,7 @@ for ((SHARD_INDEX=0; SHARD_INDEX<NUM_GPUS; SHARD_INDEX++)); do
   CUDA_VISIBLE_DEVICES="$SHARD_INDEX" python3 -m metricx24.score_dialog_outputs \
     --tokenizer "$TOKENIZER_SNAPSHOT" \
     --model_name_or_path "$MODEL_SNAPSHOT" \
-    --input_dirs "$INPUT_DIR_1" "$INPUT_DIR_2" "$INPUT_DIR_3" \
+    --input_dirs "$INPUT_DIR_1" "$INPUT_DIR_2" "$INPUT_DIR_3" "$INPUT_DIR_4" "$INPUT_DIR_5" \
     --output_dir "$OUTPUT_DIR" \
     --batch_size "$BATCH_SIZE" \
     --max_input_length "$MAX_INPUT_LENGTH" \

--- a/run_metricx_score_v3_r1.sh
+++ b/run_metricx_score_v3_r1.sh
@@ -8,9 +8,12 @@ MODEL_SNAPSHOT="${MODEL_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--metricx
 TOKENIZER_SNAPSHOT="${TOKENIZER_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--mt5-xl/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
 
 OUTPUT_DIR="${OUTPUT_DIR:-/llm-align/liuchonghan/metricx_result}"
-BATCH_SIZE="${BATCH_SIZE:-256}"
+BATCH_SIZE="${BATCH_SIZE:-512}"
 MAX_INPUT_LENGTH="${MAX_INPUT_LENGTH:-1024}"
 NUM_GPUS="${NUM_GPUS:-8}"
+PREPROCESSING_NUM_WORKERS="${PREPROCESSING_NUM_WORKERS:-8}"
+DATALOADER_NUM_WORKERS="${DATALOADER_NUM_WORKERS:-4}"
+USE_BF16="${USE_BF16:-1}"
 
 INPUT_DIR_1="${INPUT_DIR_1:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_1}"
 INPUT_DIR_2="${INPUT_DIR_2:-/llm-align/duyimin/multi_lang/v3_r1/result_top_lang_train_data_sample_2_t0.9}"
@@ -38,10 +41,18 @@ echo "output_dir=$OUTPUT_DIR"
 echo "batch_size=$BATCH_SIZE"
 echo "max_input_length=$MAX_INPUT_LENGTH"
 echo "num_gpus=$NUM_GPUS"
+echo "preprocessing_num_workers=$PREPROCESSING_NUM_WORKERS"
+echo "dataloader_num_workers=$DATALOADER_NUM_WORKERS"
+echo "use_bf16=$USE_BF16"
 echo "input_dirs:"
 echo "  $INPUT_DIR_1"
 echo "  $INPUT_DIR_2"
 echo "  $INPUT_DIR_3"
+
+EXTRA_ARGS=()
+if [[ "$USE_BF16" == "1" ]]; then
+  EXTRA_ARGS+=(--bf16)
+fi
 
 PIDS=()
 for ((SHARD_INDEX=0; SHARD_INDEX<NUM_GPUS; SHARD_INDEX++)); do
@@ -54,8 +65,11 @@ for ((SHARD_INDEX=0; SHARD_INDEX<NUM_GPUS; SHARD_INDEX++)); do
     --output_dir "$OUTPUT_DIR" \
     --batch_size "$BATCH_SIZE" \
     --max_input_length "$MAX_INPUT_LENGTH" \
+    --preprocessing_num_workers "$PREPROCESSING_NUM_WORKERS" \
+    --dataloader_num_workers "$DATALOADER_NUM_WORKERS" \
     --num_shards "$NUM_GPUS" \
     --shard_index "$SHARD_INDEX" \
+    "${EXTRA_ARGS[@]}" \
     --qe > "$LOG_FILE" 2>&1 &
   PIDS+=("$!")
 done

--- a/run_metricx_score_v3_r1.sh
+++ b/run_metricx_score_v3_r1.sh
@@ -8,7 +8,7 @@ MODEL_SNAPSHOT="${MODEL_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--metricx
 TOKENIZER_SNAPSHOT="${TOKENIZER_SNAPSHOT:-$(find "$HF_CACHE_ROOT/models--google--mt5-xl/snapshots" -mindepth 1 -maxdepth 1 -type d | head -n 1)}"
 
 OUTPUT_DIR="${OUTPUT_DIR:-/llm-align/liuchonghan/metricx_result}"
-BATCH_SIZE="${BATCH_SIZE:-512}"
+BATCH_SIZE="${BATCH_SIZE:-128}"
 MAX_INPUT_LENGTH="${MAX_INPUT_LENGTH:-1024}"
 NUM_GPUS="${NUM_GPUS:-8}"
 PREPROCESSING_NUM_WORKERS="${PREPROCESSING_NUM_WORKERS:-8}"


### PR DESCRIPTION
## Summary

This PR fixes a few practical issues around inference and installation:

- keep requirements.txt inference-only and document mt-metrics-eval as an extra dependency for meta-evaluation
- make prediction output JSONL human-readable for non-ASCII text
- add a padding collator and safer per-device batch size handling in metricx23.predict
- handle output_file paths without a parent directory in both predict scripts

## Why

Directly installing requirements.txt currently pulls in a VCS dependency that is only needed for meta-evaluation, which makes inference setup more fragile than necessary.

Also, both predict scripts currently write JSON using the default ensure_ascii=True, so multilingual content is emitted as Unicode escape sequences. In practice this makes output files harder to inspect.

Finally, metricx23.predict was missing a padding collator, which can break batched inference on variable-length inputs, and its per-device batch size could become zero when the global batch size is smaller than the GPU count.

## Validation

- python3 -m py_compile metricx23/predict.py metricx24/predict.py
